### PR TITLE
refactor(storage): dynamic team storage calculation, remove storage_used column

### DIFF
--- a/app/Console/Commands/SyncTranslations.php
+++ b/app/Console/Commands/SyncTranslations.php
@@ -50,8 +50,8 @@ class SyncTranslations extends Command
                     )
                 )
             )
-            ->filter(fn($file) => $file->isFile() && str_ends_with($file->getFilename(), '.blade.php'))
-            ->map(fn($file) => $file->getPathname());
+                ->filter(fn ($file) => $file->isFile() && str_ends_with($file->getFilename(), '.blade.php'))
+                ->map(fn ($file) => $file->getPathname());
         }
 
         return $files;
@@ -94,7 +94,7 @@ class SyncTranslations extends Command
             $added = 0;
 
             foreach ($keys as $key) {
-                if (!array_key_exists($key, $json)) {
+                if (! array_key_exists($key, $json)) {
                     $json[$key] = $key;
                     $added++;
                 }
@@ -104,9 +104,9 @@ class SyncTranslations extends Command
                 ksort($json);
                 file_put_contents($langFile, json_encode($json, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
 
-                $this->info("Added $added missing keys to " . basename($langFile));
+                $this->info("Added $added missing keys to ".basename($langFile));
             } else {
-                $this->info("No missing keys in " . basename($langFile));
+                $this->info('No missing keys in '.basename($langFile));
             }
         }
     }

--- a/app/Jobs/ProcessPhoto.php
+++ b/app/Jobs/ProcessPhoto.php
@@ -53,7 +53,7 @@ class ProcessPhoto implements ShouldQueue
     {
         $previousPath = $this->photo->path;
 
-        if (!$this->photo->gallery->keep_original_size) {
+        if (! $this->photo->gallery->keep_original_size) {
             Image::load($this->temporaryPhotoPath)
                 ->width(config('picstome.photo_resize'))
                 ->height(config('picstome.photo_resize'))

--- a/app/Livewire/Forms/UserForm.php
+++ b/app/Livewire/Forms/UserForm.php
@@ -15,7 +15,7 @@ class UserForm extends Form
     {
         $this->user = $user;
 
-        $this->custom_storage_limit = $user->personalTeam()->custom_storage_limit
+        $this->custom_storage_limit = ! is_null($user->personalTeam()->custom_storage_limit)
             ? round($user->personalTeam()->storage_limit / 1073741824, 2) // Convert bytes to GB
             : null;
     }

--- a/app/Models/Gallery.php
+++ b/app/Models/Gallery.php
@@ -106,7 +106,7 @@ class Gallery extends Model
             ),
         ]);
 
-        $team->increment('storage_used', $photoSize);
+
 
         return $photoModel;
     }

--- a/app/Models/Gallery.php
+++ b/app/Models/Gallery.php
@@ -106,8 +106,6 @@ class Gallery extends Model
             ),
         ]);
 
-
-
         return $photoModel;
     }
 

--- a/app/Models/Photo.php
+++ b/app/Models/Photo.php
@@ -16,13 +16,6 @@ class Photo extends Model
 
     protected $guarded = [];
 
-    public static function booted()
-    {
-        static::deleting(function (Photo $photo) {
-
-        });
-    }
-
     protected function casts()
     {
         return [

--- a/app/Models/Photo.php
+++ b/app/Models/Photo.php
@@ -19,7 +19,7 @@ class Photo extends Model
     public static function booted()
     {
         static::deleting(function (Photo $photo) {
-            $photo->gallery->team->decrement('storage_used', $photo->size);
+
         });
     }
 

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Laravel\Cashier\Billable;
 
@@ -192,5 +193,16 @@ class Team extends Model
     public function stripeEmail()
     {
         return $this->owner->email ?? null;
+    }
+
+    /**
+     * Dynamically calculate total storage used by all galleries/photos for this team.
+     */
+    public function calculateStorageUsedFromDatabase(): int
+    {
+        return DB::table('photos')
+            ->join('galleries', 'photos.gallery_id', '=', 'galleries.id')
+            ->where('galleries.team_id', $this->id)
+            ->sum('photos.size');
     }
 }

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -25,7 +25,7 @@ class Team extends Model
             return true;
         }
 
-        return ($this->storage_used + $size) <= $this->storage_limit;
+        return ($this->calculateStorageUsed() + $size) <= $this->storage_limit;
     }
 
     protected function casts()
@@ -142,7 +142,7 @@ class Team extends Model
     protected function storageUsedGb(): Attribute
     {
         return Attribute::get(function () {
-            $gb = $this->storage_used / 1073741824;
+            $gb = $this->calculateStorageUsed() / 1073741824;
 
             return number_format($gb, 2).' GB';
         });
@@ -167,7 +167,7 @@ class Team extends Model
                 return 100;
             }
 
-            $percent = ($this->storage_used / $this->storage_limit) * 100;
+            $percent = ($this->calculateStorageUsed() / $this->storage_limit) * 100;
 
             return number_format($percent);
         });

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -197,8 +197,10 @@ class Team extends Model
 
     /**
      * Dynamically calculate total storage used by all galleries/photos for this team.
+     *
+     * @return int Total bytes used
      */
-    public function calculateStorageUsedFromDatabase(): int
+    public function calculateStorageUsed(): int
     {
         return DB::table('photos')
             ->join('galleries', 'photos.gallery_id', '=', 'galleries.id')

--- a/database/migrations/2025_08_03_161631_remove_storage_used_from_teams_table.php
+++ b/database/migrations/2025_08_03_161631_remove_storage_used_from_teams_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('teams', function (Blueprint $table) {
+            $table->dropColumn('storage_used');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('teams', function (Blueprint $table) {
+            $table->bigInteger('storage_used')->default(0);
+        });
+    }
+};

--- a/tests/Feature/ShowGalleryPageTest.php
+++ b/tests/Feature/ShowGalleryPageTest.php
@@ -382,8 +382,12 @@ describe('Storage Limits', function () {
 
         $this->team->update([
             'custom_storage_limit' => 20 * 1024, // 20 KB
-            'storage_used' => 18 * 1024, // 18 KB used
         ]);
+
+        Photo::factory()->for(
+            Gallery::factory()->for($this->team)
+        )->create(['size' => 18 * 1024]); // 18 KB
+
         $gallery = Gallery::factory()->for($this->team)->create();
 
         $photoFile = UploadedFile::fake()->image('photo_upload.jpg', 1200, 800)->size(5 * 1024); // 5 KB
@@ -406,8 +410,12 @@ describe('Storage Limits', function () {
 
         $this->team->update([
             'custom_storage_limit' => 20 * 1024, // 20 KB
-            'storage_used' => 20 * 1024, // exactly at the limit
         ]);
+
+        Photo::factory()->for(
+            Gallery::factory()->for($this->team)
+        )->create(['size' => 20 * 1024]); // 20 KB
+
         $gallery = Gallery::factory()->for($this->team)->create(['ulid' => 'STORAGEFULL']);
 
         $photoFile = UploadedFile::fake()->image('photo_upload.jpg', 1200, 800)->size(5 * 1024); // 5 KB
@@ -430,8 +438,12 @@ describe('Storage Limits', function () {
 
         $this->team->update([
             'custom_storage_limit' => 20 * 1024, // 20 KB
-            'storage_used' => 19 * 1024, // just under the limit
         ]);
+
+        Photo::factory()->for(
+            Gallery::factory()->for($this->team)
+        )->create(['size' => 19 * 1024]); // 19 KB
+
         $gallery = Gallery::factory()->for($this->team)->create(['ulid' => 'STORAGEALMOSTFULL']);
 
         $photoFile = UploadedFile::fake()->image('photo_upload.jpg', 1200, 800)->size(2 * 1024); // 2 KB
@@ -453,8 +465,8 @@ describe('Storage Limits', function () {
 
         $this->team->update([
             'custom_storage_limit' => 100 * 1024 * 1024, // 100 MB
-            'storage_used' => 0,
         ]);
+        // No photos yet, so storage used is 0
         $gallery = Gallery::factory()->for($this->team)->create(['ulid' => 'STORAGEDELETE']);
 
         $photoFile = UploadedFile::fake()->image('photo_delete.jpg', 1200, 800)->size(5 * 1024); // 5 KB
@@ -481,8 +493,12 @@ describe('Storage Limits', function () {
 
         $this->team->update([
             'custom_storage_limit' => null, // Unlimited storage
-            'storage_used' => 999999999, // Simulate huge usage
         ]);
+
+        Photo::factory()->for(
+            Gallery::factory()->for($this->team)
+        )->create(['size' => 999999999]); // 999 MB
+
         $gallery = Gallery::factory()->for($this->team)->create(['ulid' => 'UNLIMITED']);
 
         $photoFile = UploadedFile::fake()->image('photo_upload.jpg', 1200, 800)->size(5 * 1024); // 5 MB

--- a/tests/Feature/SyncTranslationsCommandTest.php
+++ b/tests/Feature/SyncTranslationsCommandTest.php
@@ -4,12 +4,12 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Artisan;
 
 it('adds missing translation keys found in Blade files to lang JSON files', function () {
-    $filesystem = new Filesystem();
+    $filesystem = new Filesystem;
 
     $bladeTestDir = resource_path('views/test_translations');
-    $bladeTestFile = $bladeTestDir . '/test.blade.php';
+    $bladeTestFile = $bladeTestDir.'/test.blade.php';
     $langTestFile = base_path('lang/test.json');
-    $uniqueTranslationKey = 'Unique Test Key ' . uniqid();
+    $uniqueTranslationKey = 'Unique Test Key '.uniqid();
 
     $filesystem->ensureDirectoryExists($bladeTestDir);
     $filesystem->put($bladeTestFile, "{{ __('$uniqueTranslationKey') }}");

--- a/tests/Feature/UsersPageTest.php
+++ b/tests/Feature/UsersPageTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\Gallery;
+use App\Models\Photo;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Volt\Volt;
@@ -96,11 +98,13 @@ describe('Users Page', function () {
 
         $team->update([
             'custom_storage_limit' => 0,
-            'storage_used' => 0,
         ]);
         expect($team->storage_used_percent)->toBe(100);
 
-        // $team->update(['storage_used' => 12345]);
+        Photo::factory()->for(
+            Gallery::factory()->for($team)
+        )->create(['size' => 12345]);
+
         expect($team->storage_used_percent)->toBe(100);
     });
 });

--- a/tests/Feature/UsersPageTest.php
+++ b/tests/Feature/UsersPageTest.php
@@ -100,7 +100,7 @@ describe('Users Page', function () {
         ]);
         expect($team->storage_used_percent)->toBe(100);
 
-        $team->update(['storage_used' => 12345]);
+        // $team->update(['storage_used' => 12345]);
         expect($team->storage_used_percent)->toBe(100);
     });
 });


### PR DESCRIPTION
## Summary
- Remove storage_used column and all related code from teams and models
- Add dynamic calculation of storage used by summing gallery/photo file sizes
- Refactor tests and commands for new storage logic
- Code style and minor logic improvements

## Test plan
- All tests pass (Pest)
- Team storage usage is now calculated dynamically
- No references to storage_used remain

🤖 Generated with [opencode](https://opencode.ai)
