### PR TITLE
Implement Localized Stripe Pricing Tables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,8 @@ VITE_APP_NAME="${APP_NAME}"
 STRIPE_KEY=your-stripe-key
 STRIPE_SECRET=your-stripe-secret
 STRIPE_WEBHOOK_SECRET=your-stripe-webhook-secret
+STRIPE_EN_PRICING_TABLE_ID=your-stripe-en-pricing-table-id
+STRIPE_ES_PRICING_TABLE_ID=your-stripe-es-pricing-table-id
 
 PICSTOME_ADMIN_EMAILS=admin@example.com
 

--- a/config/services.php
+++ b/config/services.php
@@ -37,6 +37,8 @@ return [
 
     'stripe' => [
         'monthly_price_id' => env('STRIPE_MONTHLY_PRICE_ID'),
+        'en_pricing_table_id' => env('STRIPE_EN_PRICING_TABLE_ID'),
+        'es_pricing_table_id' => env('STRIPE_ES_PRICING_TABLE_ID'),
     ],
 
 ];

--- a/resources/views/pages/subscribe.blade.php
+++ b/resources/views/pages/subscribe.blade.php
@@ -20,7 +20,7 @@ new class extends Component
 
     public $pricingTableId;
 
-    public function mount(Request $request)
+    public function mount()
     {
         Stripe::setApiKey(config('cashier.secret'));
 


### PR DESCRIPTION
## Summary
- Enable localized Stripe pricing tables to support different pricing for English and Spanish locales
- Add configuration for separate pricing table IDs in services config
- Update subscribe page to dynamically select pricing table based on current locale