### PR TITLE
ui: enhance favorite list export with copy functionality and i18n

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -34,6 +34,7 @@
     "Are you sure you want to delete this bio link?": "Are you sure you want to delete this bio link?",
     "Are you sure you want to delete this payment?": "Are you sure you want to delete this payment?",
     "Are you sure?": "Are you sure?",
+    "Export": "Export",
     "Awaiting signature": "Awaiting signature",
     "Before you can accept payments, you must complete your Stripe Connect onboarding process.": "Before you can accept payments, you must complete your Stripe Connect onboarding process.",
     "Begin Stripe Onboarding": "Begin Stripe Onboarding",

--- a/lang/es.json
+++ b/lang/es.json
@@ -50,7 +50,7 @@
     "Are you sure you want to delete this payment?": "¿Estás seguro de que quieres eliminar este pago?",
     "Are you sure you want to disconnect your Stripe account?": "¿Estás seguro de que quieres desconectar tu cuenta de Stripe?",
     "Are you sure?": "¿Estás seguro?",
-    "As list": "Como lista",
+    "Export": "Exportar",
     "Assign": "Asignar",
     "Assign to Photoshoot": "Asignar a sesión de fotos",
     "Assign to photoshoot": "Asignar a sesión de fotos",

--- a/resources/views/pages/galleries/[Gallery].blade.php
+++ b/resources/views/pages/galleries/[Gallery].blade.php
@@ -328,7 +328,7 @@ new class extends Component
                         </flux:navbar.item>
                         @if ($favorites->isNotEmpty())
                             <flux:modal.trigger name="favorite-list">
-                                <flux:badge size="sm" as="button">{{ __('As list') }}</flux:badge>
+                                <flux:badge size="sm" as="button">{{ __('Export') }}</flux:badge>
                             </flux:modal.trigger>
                         @endif
 


### PR DESCRIPTION
## Summary
- Add functional copy buttons to favorite list modal with visual feedback
- Remove file extensions from exported photo names for cleaner output
- Implement proper internationalization with pluralization support
- Change "As list" button text to "Export" for clarity
- Support multiple export formats (Lightroom, Capture One, Finder/Explorer)

## Changes Made
- **Copy Functionality**: Added JavaScript to copy textarea content with temporary "Copied!" feedback
- **File Extensions**: Strip extensions from photo names using PHP's `pathinfo()`
- **Internationalization**: Wrapped all strings in `__()` with proper pluralization using `:count`
- **Translations**: Added Spanish translations using "Foto/Video" for "Media" as requested
- **UI Improvements**: Changed button text from "As list" to "Export" for better UX

## Technical Details
- Uses Alpine.js for reactive copy functionality
- Laravel's pluralization system for proper singular/plural handling
- Maintains existing modal structure while enhancing functionality